### PR TITLE
add maven to repos to help resolve dependencies during build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
@@ -15,9 +19,14 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+


### PR DESCRIPTION
sync failed, unresolved dependencies, android studios suggestion was to
add Google Maven repository and sync project
errors that were resolved:
ERROR: Failed to resolve: com.android.support.test.espresso:espresso-core:2.2.2
ERROR: Failed to resolve: com.android.support:appcompat-v7:25.3.1
ERROR: Failed to resolve: com.android.support.constraint:constraint-layout:1.0.2